### PR TITLE
Fenced code block delimited by tilde ~ characters

### DIFF
--- a/src/main/java/com/github/rjeschke/txtmark/Emitter.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Emitter.java
@@ -773,6 +773,7 @@ class Emitter
             case '_':
             case '!':
             case '`':
+            case '~':
             case '^':
                 return MarkToken.ESCAPE;
             default:

--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -138,6 +138,7 @@ class Line
                 case '_':
                 case '!':
                 case '`':
+                case '~':
                     sb.append(c);
                     pos++;
                     break;
@@ -263,9 +264,11 @@ class Line
 
         if(extendedMode)
         {
-            if(this.value.length() - this.leading - this.trailing > 2 && this.value.charAt(this.leading) == '`')
+            if(this.value.length() - this.leading - this.trailing > 2)
             {
-                if(this.countCharsStart('`') >= 3)
+                if(this.value.charAt(this.leading) == '`' && this.countCharsStart('`') >= 3)
+                    return LineType.FENCED_CODE;
+                if(this.value.charAt(this.leading) == '~' && this.countCharsStart('~') >= 3)
                     return LineType.FENCED_CODE;
             }
         }

--- a/src/main/java/com/github/rjeschke/txtmark/Utils.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Utils.java
@@ -639,11 +639,11 @@ class Utils
     }
 
     /**
-     * Removes trailing <code>`</code> and trims spaces.
+     * Removes trailing <code>`</code> or <code>~</code> and trims spaces.
      * 
      * @param fenceLine
      *            Fenced code block starting line
-     * @return Rest of the line after trimming and backtick removal
+     * @return Rest of the line after trimming and backtick or tilde removal
      * @since 0.7
      */
     public final static String getMetaFromFence(String fenceLine)
@@ -651,7 +651,7 @@ class Utils
         for(int i = 0; i < fenceLine.length(); i++)
         {
             final char c = fenceLine.charAt(i);
-            if(!Character.isWhitespace(c) && c != '`')
+            if(!Character.isWhitespace(c) && c != '`' && c != '~' )
             {
                 return fenceLine.substring(i).trim();
             }


### PR DESCRIPTION
Hi René

This is only small fix for fenced code blocks, which can be delimited with tilde ~ characters also.

Cheers T.
