### PR TITLE
Tighter handling of HTML/XML elements

### DIFF
--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -530,13 +530,14 @@ class Line
         {
             element = temp.toString();
             temp.setLength(0);
-            Utils.getXMLTag(temp, element);
-            tag = temp.toString().toLowerCase();
-            if (!HTML.isHtmlBlockElement(tag))
+            Utils.getXMLTag(temp, element, 0);
+            tag = temp.toString();
+            if (!HTML.isHtmlBlockElement(tag.toLowerCase()) && !Utils.isQName(tag))
             {
                 return false;
             }
-            if (tag.equals("hr"))
+            if (tag.equalsIgnoreCase("hr") ||
+                    ((element.length() > 2) && (element.charAt(element.length() - 2) == '/')))
             {
                 this.xmlEndLine = this;
                 return true;
@@ -563,9 +564,9 @@ class Line
                     {
                         element = temp.toString();
                         temp.setLength(0);
-                        Utils.getXMLTag(temp, element);
-                        tag = temp.toString().toLowerCase();
-                        if (HTML.isHtmlBlockElement(tag) && !tag.equals("hr"))
+                        Utils.getXMLTag(temp, element, 0);
+                        tag = temp.toString();
+                        if ((HTML.isHtmlBlockElement(tag.toLowerCase()) && !tag.equalsIgnoreCase("hr")) || Utils.isQName(tag))
                         {
                             if (element.charAt(1) == '/')
                             {
@@ -577,7 +578,10 @@ class Line
                             }
                             else
                             {
-                                tags.addLast(tag);
+                                if ((element.length() <= 2) || (element.charAt(element.length() - 2) != '/'))
+                                {
+                                    tags.addLast(tag);
+                                }
                             }
                         }
                         if (tags.size() == 0)

--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -349,7 +349,7 @@ class Line
 
         if (this.value.charAt(this.leading) == '<')
         {
-            if (this.checkHTML())
+            if (this.checkHTML(configuration.forceExtendedProfile))
             {
                 return LineType.XML;
             }
@@ -512,7 +512,7 @@ class Line
      *
      * @return <code>true</code> if it is a valid block.
      */
-    private boolean checkHTML()
+    private boolean checkHTML(boolean extendedProfile)
     {
         final LinkedList<String> tags = new LinkedList<String>();
         final StringBuilder temp = new StringBuilder();
@@ -532,7 +532,7 @@ class Line
             temp.setLength(0);
             Utils.getXMLTag(temp, element, 0);
             tag = temp.toString();
-            if (!HTML.isHtmlBlockElement(tag.toLowerCase()) && !Utils.isQName(tag))
+            if (!HTML.isHtmlBlockElement(tag.toLowerCase()) && (!extendedProfile || !Utils.isQName(tag)))
             {
                 return false;
             }

--- a/src/main/java/com/github/rjeschke/txtmark/Utils.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Utils.java
@@ -604,7 +604,13 @@ class Utils
      */
     public final static int getXMLTag(final StringBuilder out, final String in, final int start)
     {
+        final int len = in.length();
         int pos = start + 1;
+
+        if (len < 3)
+        {
+            return -1;
+        }
         if (in.charAt(pos) == '/')
         {
             pos++;
@@ -612,26 +618,22 @@ class Utils
 
         final int nmStart = pos;
 
-        // Read an NCName
+        // Read a QName
         if (isNameStartChar(in.charAt(pos)))
         {
             pos++;
-            while (isNameChar(in.charAt(pos)))
+            while (pos < len && isQNameChar(in.charAt(pos)))
             {
                 pos++;
             }
 
-            // optional - read the remainder of a prefixed name (QName)
-            if (in.charAt(pos) == ':')
+            // Check for a legitimate separator
+            if (pos < len)
             {
-                // Read the local part
-                if (isNameStartChar(in.charAt(pos)))
+                final char c = in.charAt(pos);
+                if ((c != ' ') && (c != '/') && (c != '>'))
                 {
-                    pos++;
-                    while (isNameChar(in.charAt(pos)))
-                    {
-                        pos++;
-                    }
+                    return -1;
                 }
             }
             out.append(in, nmStart, pos);
@@ -662,6 +664,10 @@ class Utils
 
     public final static boolean isNameChar(char c) {
         return Character.isLetterOrDigit(c) || c == '-' || c == '_' || c == '.';
+    }
+
+    public final static boolean isQNameChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '-' || c == '_' || c == '.' || c == ':';
     }
 
     public final static boolean isQName(String name) {

--- a/src/main/java/com/github/rjeschke/txtmark/Utils.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Utils.java
@@ -696,7 +696,6 @@ class Utils
             if (in.charAt(start + 1) == '/')
             {
                 isCloseTag = true;
-                pos = start + 2;
             }
             else if (in.charAt(start + 1) == '!')
             {
@@ -706,7 +705,6 @@ class Utils
             else
             {
                 isCloseTag = false;
-                pos = start + 1;
             }
             if (safeMode)
             {


### PR DESCRIPTION
Tighter handling of HTML/XML elements:
- Text such as `<&>` is treated as plain-text.
- Handle self-terminating elements, like `<tag />`.
- Handle qualified XML elements (QNames) containing colons,
  like `<xml:element>`. 
- Convert to lowercase only for testing block HTML tags. 
- Tidy up `getXMLTag()` to check length of the input string.
- Bulk copy into `StringBuilder` -- Visual VM optimization.
