### PR TITLE
GitHub Flavored Markdown extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>7</version>
   </parent>
 
-  <groupId>com.github.rjeschke</groupId>
+  <groupId>com.quandora</groupId>
   <artifactId>txtmark</artifactId>
   <version>0.14-SNAPSHOT</version>
   <name>txtmark</name>
@@ -29,9 +29,9 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git@github.com/rjeschke/txtmark.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/rjeschke/txtmark.git</developerConnection>
-    <url>git@github.com/rjeschke/txtmark.git</url>
+    <connection>scm:git:git@github.com/quandora/txtmark.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/quandora/txtmark.git</developerConnection>
+    <url>git@github.com/quandora/txtmark.git</url>
   </scm>
 
   <developers>

--- a/src/main/java/com/github/rjeschke/txtmark/BlockType.java
+++ b/src/main/java/com/github/rjeschke/txtmark/BlockType.java
@@ -43,5 +43,7 @@ enum BlockType
     /** An unordered list. */
     UNORDERED_LIST,
     /** A XML block. */
-    XML
+    XML,
+    /** A GFM table */
+    TABLE
 }

--- a/src/main/java/com/github/rjeschke/txtmark/Decorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Decorator.java
@@ -502,4 +502,200 @@ public interface Decorator
      *            The StringBuilder to write to.
      */
     public void closeImage(final StringBuilder out);
+
+    /**
+     * Called when a table is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<table>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void openTable(final StringBuilder out);
+
+    /**
+     * Called when a table is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</table>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTable(final StringBuilder out);
+
+    /**
+     * Called when a table body is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<tbody>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void openTableBody(final StringBuilder out);
+
+    /**
+     * Called when a table body is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</tbody>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTableBody(final StringBuilder out);
+
+    /**
+     * Called when a table head is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<thead>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void openTableHead(final StringBuilder out);
+
+    /**
+     * Called when a table head is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</thead>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTableHead(final StringBuilder out);
+
+    /**
+     * Called when a table row is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<tr>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void openTableRow(final StringBuilder out);
+
+    /**
+     * Called when a table row is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</tr>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTableRow(final StringBuilder out);
+
+    /**
+     * Called when a table data is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<td>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     * @param align one of null | left | center | right.
+     *            If null no align is set
+     */
+    public void openTableData(final StringBuilder out, final String align);
+
+    /**
+     * Called when a table data is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</td>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTableData(final StringBuilder out);
+
+    /**
+     * Called when a table header is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("<th>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     * @param align one of null | left | center | right.
+     *            If null no align is set
+     */
+    public void openTableHeader(final StringBuilder out, final String align);
+
+    /**
+     * Called when a table header is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("</th>");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeTableHeader(final StringBuilder out);
 }

--- a/src/main/java/com/github/rjeschke/txtmark/Decorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Decorator.java
@@ -149,6 +149,19 @@ public interface Decorator
     public void closeCodeSpan(final StringBuilder out);
 
     /**
+     * Called to append the content in a code span
+     * This will call {@link #openCodeSpan(StringBuilder)} then write the content and then call {@link #closeCodeSpan(StringBuilder)}
+     *
+     * TODO: better use a CodeSpanEmmiter?
+     *
+     * @param out
+     * @param in
+     * @param start
+     * @param end
+     */
+    public void appendCodeSpan(final StringBuilder out, final String in, final int start, final int end);
+
+    /**
      * Called when a headline is opened.
      *
      * <p>

--- a/src/main/java/com/github/rjeschke/txtmark/Decorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Decorator.java
@@ -255,6 +255,38 @@ public interface Decorator
     public void closeEmphasis(final StringBuilder out);
 
     /**
+     * Called when a strikeout span is opened.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("&lt;del&gt;");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void openStrikeout(final StringBuilder out);
+
+    /**
+     * Called when a strikeout span is closed.
+     *
+     * <p>
+     * Default implementation is:
+     * </p>
+     *
+     * <pre>
+     * <code>out.append("&lt;/del&gt;");</code>
+     * </pre>
+     *
+     * @param out
+     *            The StringBuilder to write to.
+     */
+    public void closeStrikeout(final StringBuilder out);
+
+    /**
      * Called when a superscript span is opened.
      *
      * <p>

--- a/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
@@ -93,6 +93,14 @@ public class DefaultDecorator implements Decorator
         out.append("<code>");
     }
 
+    /** @see com.github.rjeschke.txtmark.Decorator#appendCodeSpan(StringBuilder) */
+    @Override
+    public void appendCodeSpan(final StringBuilder out, final String in, final int start, final int end) {
+        openCodeSpan(out);
+        Utils.appendCode(out, in, start, end);
+        closeCodeSpan(out);
+    }
+
     /** @see com.github.rjeschke.txtmark.Decorator#closeCodeSpan(StringBuilder) */
     @Override
     public void closeCodeSpan(final StringBuilder out)

--- a/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
@@ -255,4 +255,96 @@ public class DefaultDecorator implements Decorator
     {
         out.append(" />");
     }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTable(java.lang.StringBuilder) */
+    @Override
+    public void openTable(final StringBuilder out)
+    {
+        out.append("<table>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTable(java.lang.StringBuilder) */
+    @Override
+    public void closeTable(final StringBuilder out)
+    {
+        out.append("</table>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTableHead(java.lang.StringBuilder) */
+    @Override
+    public void openTableHead(final StringBuilder out)
+    {
+        out.append("<thead>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTableHead(java.lang.StringBuilder) */
+    @Override
+    public void closeTableHead(final StringBuilder out)
+    {
+        out.append("</thead>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTableBody(java.lang.StringBuilder) */
+    @Override
+    public void openTableBody(final StringBuilder out)
+    {
+        out.append("<tbody>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTableBody(java.lang.StringBuilder) */
+    @Override
+    public void closeTableBody(final StringBuilder out)
+    {
+        out.append("</tbody>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTableRow(java.lang.StringBuilder) */
+    @Override
+    public void openTableRow(final StringBuilder out)
+    {
+        out.append("<tr>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTableRow(java.lang.StringBuilder) */
+    @Override
+    public void closeTableRow(final StringBuilder out)
+    {
+        out.append("</tr>\n");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTableData(java.lang.StringBuilder,java.lang.String) */
+    @Override
+    public void openTableData(final StringBuilder out, final String align)
+    {
+        if (align == null) {
+            out.append("<td>");
+        } else {
+            out.append("<td style=\"text-align:").append(align).append(";\">");
+        }
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTableData(java.lang.StringBuilder) */
+    @Override
+    public void closeTableData(final StringBuilder out)
+    {
+        out.append("</td>");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#openTableHeader(java.lang.StringBuilder,java.lang.String) */
+    @Override
+    public void openTableHeader(final StringBuilder out, final String align)
+    {
+        if (align == null) {
+            out.append("<th>");
+        } else {
+            out.append("<th style=\"text-align:").append(align).append(";\">");
+        }
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeTableHeader(java.lang.StringBuilder) */
+    @Override
+    public void closeTableHeader(final StringBuilder out)
+    {
+        out.append("</th>");
+    }
 }

--- a/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
+++ b/src/main/java/com/github/rjeschke/txtmark/DefaultDecorator.java
@@ -151,6 +151,20 @@ public class DefaultDecorator implements Decorator
         out.append("</em>");
     }
 
+    /** @see com.github.rjeschke.txtmark.Decorator#openStrikeout(StringBuilder) */
+    @Override
+    public void openStrikeout(final StringBuilder out)
+    {
+        out.append("<del>");
+    }
+
+    /** @see com.github.rjeschke.txtmark.Decorator#closeStrikeout(StringBuilder) */
+    @Override
+    public void closeStrikeout(final StringBuilder out)
+    {
+        out.append("</del>");
+    }
+
     /** @see com.github.rjeschke.txtmark.Decorator#openSuper(StringBuilder) */
     @Override
     public void openSuper(final StringBuilder out)

--- a/src/main/java/com/github/rjeschke/txtmark/Emitter.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Emitter.java
@@ -559,7 +559,7 @@ class Emitter
             final MarkToken mt = this.getToken(in, pos);
             if (token != MarkToken.NONE && token != MarkToken.LINK
                     && (mt == token || token == MarkToken.EM_STAR && mt == MarkToken.STRONG_STAR || token == MarkToken.EM_UNDERSCORE
-                            && mt == MarkToken.STRONG_UNDERSCORE))
+                    && mt == MarkToken.STRONG_UNDERSCORE))
             {
                 return pos;
             }
@@ -659,9 +659,7 @@ class Emitter
                         {
                             b--;
                         }
-                        this.config.decorator.openCodeSpan(out);
-                        Utils.appendCode(out, in, a, b);
-                        this.config.decorator.closeCodeSpan(out);
+                        this.config.decorator.appendCodeSpan(out, in, a, b);
                     }
                 }
                 else

--- a/src/main/java/com/github/rjeschke/txtmark/Emitter.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Emitter.java
@@ -602,6 +602,21 @@ class Emitter
                     out.append(in.charAt(pos));
                 }
                 break;
+            case STRIKEOUT:
+                temp.setLength(0);
+                b = this.recursiveEmitLine(temp, in, pos + 2, mt);
+                if (b > 0)
+                {
+                    this.config.decorator.openStrikeout(out);
+                    out.append(temp);
+                    this.config.decorator.closeStrikeout(out);
+                    pos = b + 1;
+                }
+                else
+                {
+                    out.append(in.charAt(pos));
+                }
+                break;
             case SUPER:
                 temp.setLength(0);
                 b = this.recursiveEmitLine(temp, in, pos + 1, mt);
@@ -781,6 +796,11 @@ class Emitter
                         : MarkToken.EM_UNDERSCORE;
             }
             return c0 != ' ' || c1 != ' ' ? MarkToken.EM_UNDERSCORE : MarkToken.NONE;
+        case '~':
+            if (this.useExtensions && c1 == '~') {
+                return MarkToken.STRIKEOUT;
+            }
+            return MarkToken.NONE;
         case '!':
             if (c1 == '[')
             {

--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -517,7 +517,7 @@ class Line
         final LinkedList<String> tags = new LinkedList<String>();
         final StringBuilder temp = new StringBuilder();
         int pos = this.leading;
-        if (this.value.charAt(this.leading + 1) == '!')
+        if (this.leading + 1 < this.value.length() && this.value.charAt(this.leading + 1) == '!')
         {
             if (this.readXMLComment(this, this.leading) > 0)
             {

--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -42,6 +42,8 @@ class Line
     public boolean prevEmpty, nextEmpty;
     /** Final line of a XML block. */
     public Line    xmlEndLine;
+    /** additional data associated with that line if any */
+    public Object data = null;
 
     /** Constructor. */
     public Line()
@@ -364,6 +366,14 @@ class Line
             if ((this.next.value.charAt(0) == '=') && (this.next.countChars('=') > 0))
             {
                 return LineType.HEADLINE1;
+            }
+            if (configuration.forceExtendedProfile && (this.previous == null || this.previous.isEmpty))
+            {
+                TableDef table = TableDef.parse(this.value, this.next.value);
+                if (table != null) {
+                    this.data = table; // attach the table definition to be used later
+                    return LineType.TABLE;
+                }
             }
         }
 

--- a/src/main/java/com/github/rjeschke/txtmark/LineType.java
+++ b/src/main/java/com/github/rjeschke/txtmark/LineType.java
@@ -39,5 +39,7 @@ enum LineType
     /** Start of a XML block. */
     XML,
     /** Fenced code block start/end */
-    FENCED_CODE
+    FENCED_CODE,
+    /** GFM table **/
+    TABLE
 }

--- a/src/main/java/com/github/rjeschke/txtmark/MarkToken.java
+++ b/src/main/java/com/github/rjeschke/txtmark/MarkToken.java
@@ -32,6 +32,8 @@ enum MarkToken
     STRONG_STAR,        // x**x
     /** __ */
     STRONG_UNDERSCORE,  // x__x
+    /** ~~ */
+    STRIKEOUT,          // ~~
     /** ` */
     CODE_SINGLE,        // `
     /** `` */

--- a/src/main/java/com/github/rjeschke/txtmark/MarkToken.java
+++ b/src/main/java/com/github/rjeschke/txtmark/MarkToken.java
@@ -46,6 +46,8 @@ enum MarkToken
     IMAGE,              // ![
     /** &amp; */
     ENTITY,             // &
+    /** https?://domain[/path][?query][#hash] */
+    GFM_AUTOLINK,       // https?://domain[/path][?query][#hash]
     /** \ */
     ESCAPE,             // \x
     /** Extended: ^ */

--- a/src/main/java/com/github/rjeschke/txtmark/Processor.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Processor.java
@@ -665,9 +665,12 @@ public class Processor
                     if (line.value.charAt(line.pos + 1) == ':')
                     {
                         line.pos += 2;
-                        line.skipSpaces();
+                        if (!line.skipSpaces())
+                        {
+                            isLinkRef = false;
+                        }
                         // Check for link syntax
-                        if (line.value.charAt(line.pos) == '<')
+                        else if (line.value.charAt(line.pos) == '<')
                         {
                             line.pos++;
                             link = line.readUntil('>');

--- a/src/main/java/com/github/rjeschke/txtmark/Processor.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Processor.java
@@ -984,6 +984,25 @@ public class Processor
                 }
                 list.expandListParagraphs();
                 break;
+            case TABLE:
+                TableDef table = (TableDef)line.data;
+                // skip the next line - which is the the table divider line
+                line = line.next.next;
+                while (line != null)
+                {
+                    if (line.isEmpty)
+                    {
+                        break;
+                    }
+                    if (!table.addRow(line.value)) {
+                        break;
+                    }
+                    line = line.next;
+                }
+                block = root.split(line != null ? line.previous : root.lineTail);
+                block.type = BlockType.TABLE;
+                line = root.lines;
+                break;
             default:
                 line = line.next;
                 break;

--- a/src/main/java/com/github/rjeschke/txtmark/TableDef.java
+++ b/src/main/java/com/github/rjeschke/txtmark/TableDef.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2011-2015 René Jeschke <rene_jeschke@yahoo.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rjeschke.txtmark;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * A GFM table definition
+ * @author bogdan@quandora.com
+ *
+ */
+public class TableDef {
+
+	/**
+	 *
+	 * @param text the text to process
+	 * @param start from where to start skiping spaces
+	 * @param end is exclusive
+	 * @return the offset of the first non space character after 'start' or -1 if none was found.
+	 */
+	public final static int skipSpaces(String text, int start, int end) {
+		int i = start;
+		while (i < end && Character.isWhitespace(text.charAt(i))) i++;
+		return i >= end ? -1 : i;
+	}
+
+	public static int skip(char c, String text, int start, int end) {
+		int i = start;
+		while (i < end && text.charAt(i) == c) i++;
+		return i >= end ? -1 : i;
+	}
+
+	/**
+	 * Skip spaces backward: starting at end until start is reached.
+	 * the end offset is exclusive and the start offset is inclusive
+	 * @param text
+	 * @param start
+	 * @param end
+	 * @return the first offset with a non space character. the offset is >= start
+	 */
+	public final static int skipSpacesBackward(String text, int start, int end) {
+		int i = end-1;
+		while (i >= start && Character.isWhitespace(text.charAt(i))) i--;
+		return i < start ? -1 : i;
+	}
+
+	public static TableDef parse(String headerLineText, String dividerLineText) {
+		TableDef table = parseTableDividerLine(dividerLineText);
+		if (table != null) {
+			table.header = table.parseRow(headerLineText);
+			if (table.header == null) {
+				table = null;
+			}
+		}
+		return table;
+	}
+
+	private static TableDef parseTableDividerLine(String lineText) {
+		int len = lineText.length();
+		int s = skipSpaces(lineText, 0, len);
+		if (s == -1) {
+			return null; // not a table divider
+		}
+		int border = 0;
+		// skip first | if any
+		char c = lineText.charAt(s);
+		if (c == '|') {
+			border |= 1;
+			s++;
+		} else if (c != '-' && c != ':') {
+			return null; // not a table
+		}
+		int e = skipSpacesBackward(lineText, 0, len);
+		c = lineText.charAt(e);
+		if (c == '|') {
+			border |= 2;
+			e--;
+		} else if (c != '-' && c != ':') {
+			return null; // not a table
+		}
+
+		// e is an exclusive offset in skipCellDivider
+		TableDef table = readTableDividerCols(lineText, s, e+1);
+		if (table != null) {
+			table.border = border;
+		}
+		return table;
+	}
+
+
+	private static TableDef readTableDividerCols(final String text, final int start, final int end) {
+		TableDef table = null;
+
+		int align = 0;
+		int i = start;
+		while (true) {
+			// at beginning of a cell after |
+			i = skipSpaces(text, i, end);
+			if (i == -1) {
+				return null; // invalid table def
+			}
+			char c = text.charAt(i);
+			if (c == ':') {
+				align = 1;
+				i = skipSpaces(text, i+1, end);
+				if (i == -1) {
+					return null;
+				}
+				c = text.charAt(i);
+				if (c != '-') {
+					return null;
+				}
+			} else if (c == '-') {
+				align = 0;
+			} else {
+				return null;
+			}
+
+			i = skip('-', text, i+1, end);
+			if (i == -1) {
+				break; // last cell
+			}
+
+			i = skipSpaces(text, i, end);
+			if (i == -1) {
+				break; // last cell
+			}
+			c = text.charAt(i);
+			if (c == ':') {
+				align |= 2;
+				i = skipSpaces(text, i+1, end);
+				if (i == -1) {
+					break; // last cell
+				}
+				c = text.charAt(i);
+				if (c != '|') {
+					return null;
+				}
+			} else if (c != '|') {
+				return null;
+			}
+
+			if (table == null) {
+				table = new TableDef();
+				table.defineColumn(align);
+			} else {
+				table.defineColumn(align);
+			}
+			i++;
+		}
+
+		if (table == null) {
+			// a single column - not a table
+			return null;
+		} else {
+			table.defineColumn(align);
+		}
+
+		return table;
+	}
+
+    private static LinkedList<String> splitColumns(String text, char delimiter) {
+        if (text == null || text.length() == 0) {
+            return null;
+        }
+        int s = 0;
+        int e = text.indexOf(delimiter, s);
+        if (e == -1) {
+        	return null; // not a column line - we require at least 2 columns
+        }
+        LinkedList<String> ar = new LinkedList<String>();
+        do {
+            String segment = text.substring(s, e).trim();
+            ar.add(segment);
+            s = e + 1;
+            e = text.indexOf(delimiter, s);
+        } while (e != -1);
+
+        int len = text.length();
+        if (s < len) {
+            String segment = text.substring(s).trim();
+            ar.add(segment);
+        } else {
+            ar.add("");
+        }
+        return ar;
+    }
+
+
+	protected int[] aligns = new int[4];
+	protected int width = 0;
+	protected int border = 0;
+	public LinkedList<String> header;
+	public List<LinkedList<String>> rows = new ArrayList<LinkedList<String>>();
+
+	public String getAlign(int i) {
+		if (i >= width) {
+			return null;
+		}
+		switch(aligns[i]) {
+		case 0: return null;
+		case 1: return "left";
+		case 2: return "right";
+		case 3: return "center";
+		}
+		return null;
+	}
+
+	private void defineColumn(int align) {
+		int newWidth = width+1;
+		if (newWidth > aligns.length) {
+			int[] tmp = new int[newWidth];
+			System.arraycopy(aligns, 0, tmp, 0, width);
+			tmp[width] = align;
+			aligns = tmp;
+			width = newWidth;
+		} else {
+			aligns[width++] = align;
+		}
+	}
+
+	/**
+	 * Parse and a add a table row if successful. If not a table row do nothing and return false;
+	 * @param lineText
+	 * @return
+	 */
+	public boolean addRow(String lineText) {
+		LinkedList<String> row = parseRow(lineText);
+		if (row != null) {
+			this.rows.add(row);
+			return true;
+		}
+		return false;
+	}
+
+	private LinkedList<String> parseRow(String lineText) {
+		LinkedList<String> cols = splitColumns(lineText, '|');
+		if (cols == null || cols.size() < 2) { // not a table row
+			return null;
+		}
+		boolean hasRightBorder = (border & 1) != 0;
+		boolean hasLeftBorder = (border & 2) != 0;
+		if (hasRightBorder && cols.getFirst().isEmpty()) {
+			cols.removeFirst();
+		} else if (hasRightBorder) {
+			// data line no right padded with | as in divider line
+			// we consider this an error
+			return null;
+		}
+		if (hasLeftBorder && cols.getLast().isEmpty()) {
+			cols.removeLast();
+		}
+
+		// complete tr with spaces if needed
+		int width = this.width;
+		int dw = width - cols.size();
+		if (dw > 0) {
+			while (dw > 0) {
+				cols.addLast("&nbsp;");
+				dw--;
+			}
+		} else if (dw < 0) { // overflow - cut
+			//TODO: should we accept overflow cells?
+			while (dw < 0) {
+				cols.removeLast();
+				dw++;
+			}
+		}
+		return cols;
+	}
+
+}

--- a/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
+++ b/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
@@ -31,7 +31,7 @@ public class GFMTest
     private static final String   RES   = "/com/github/rjeschke/txtmark/testsuite/gfm/";
     private static final String[] TESTS =
     {
-            "GFM strikeout", "GFM Autolink"
+            "GFM strikeout", "GFM Autolink", "GFM Tables"
     };
 
     private final static String readTextUTF_8(final InputStream in) throws IOException

--- a/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
+++ b/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2011-2015 René Jeschke <rene_jeschke@yahoo.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rjeschke.txtmark;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GFMTest
+{
+    private static final Charset  UTF_8 = Charset.forName("UTF-8");
+    private static final String   RES   = "/com/github/rjeschke/txtmark/testsuite/gfm/";
+    private static final String[] TESTS =
+    {
+            "GFM strikeout"
+    };
+
+    private final static String readTextUTF_8(final InputStream in) throws IOException
+    {
+        final Reader r = new BufferedReader(new InputStreamReader(in, UTF_8));
+        final StringBuilder sb = new StringBuilder();
+        try
+        {
+            for (;;)
+            {
+                final int ch = r.read();
+                if (ch > -1)
+                {
+                    sb.append((char)ch);
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return sb.toString();
+        }
+        finally
+        {
+            in.close();
+        }
+    }
+
+    public final static String collapseWhitespace(final String str)
+    {
+        boolean wasWs = false;
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < str.length(); i++)
+        {
+            final char ch = str.charAt(i);
+            if (Character.isWhitespace(ch) || Character.isSpaceChar(ch))
+            {
+                if (!wasWs)
+                {
+                    sb.append(' ');
+                    wasWs = true;
+                }
+            }
+            else
+            {
+                wasWs = false;
+                sb.append(ch);
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    public final static String replaceHacks(final String str)
+    {
+        return str
+                .replace(" />", "/>")
+                .replace(" <", "<");
+    }
+
+    public final static String tidy(final String str)
+    {
+        return replaceHacks(collapseWhitespace(str));
+    }
+
+    @Test
+    public void test() throws IOException
+    {
+        for (final String name : TESTS)
+        {
+            final InputStream txtIn = GFMTest.class.getResourceAsStream(RES + name + ".text");
+            final InputStream cmpIn = GFMTest.class.getResourceAsStream(RES + name + ".html");
+            if (txtIn == null || cmpIn == null)
+            {
+                Assert.fail("Unmatched test resources");
+            }
+
+            final String text = readTextUTF_8(txtIn);
+            final String compare = readTextUTF_8(cmpIn);
+
+            final String processed = Processor.process(text, Configuration.builder().forceExtentedProfile().build());
+
+            final String tCompare = tidy(compare);
+            final String tProcessed = tidy(processed);
+
+            if (!tCompare.equals(tProcessed))
+            {
+                System.out.println("Test: " + name);
+                System.out.println("=============================================");
+                System.out.println(tProcessed);
+                System.out.println("---------------------------------------------");
+                System.out.println(tCompare);
+                System.out.println("=============================================");
+                System.out.println(processed);
+                System.out.println("---------------------------------------------");
+                System.out.println(compare);
+                System.out.println("=============================================");
+                Assert.fail("Test '" + name + "' failed");
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
+++ b/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
@@ -31,7 +31,7 @@ public class GFMTest
     private static final String   RES   = "/com/github/rjeschke/txtmark/testsuite/gfm/";
     private static final String[] TESTS =
     {
-            "GFM strikeout"
+            "GFM strikeout", "GFM Autolink"
     };
 
     private final static String readTextUTF_8(final InputStream in) throws IOException

--- a/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
+++ b/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
@@ -105,7 +105,18 @@ public class GFMTest
             final InputStream cmpIn = GFMTest.class.getResourceAsStream(RES + name + ".html");
             if (txtIn == null || cmpIn == null)
             {
-                Assert.fail("Unmatched test resources: "+name);
+                StringBuilder details = new StringBuilder();
+                details.append("Resource(s) not found: ");
+                if (txtIn == null) {
+                    details.append(RES + name + ".text");
+                }
+                if (cmpIn == null) {
+                    if (details.length() > 0) {
+                        details.append(", ");
+                    }
+                    details.append(RES + name + ".html");
+                }
+                Assert.fail("Unmatched test resources: '"+name+"' - "+details.toString());
             }
 
             final String text = readTextUTF_8(txtIn);

--- a/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
+++ b/src/test/java/com/github/rjeschke/txtmark/GFMTest.java
@@ -30,9 +30,9 @@ public class GFMTest
     private static final Charset  UTF_8 = Charset.forName("UTF-8");
     private static final String   RES   = "/com/github/rjeschke/txtmark/testsuite/gfm/";
     private static final String[] TESTS =
-    {
-            "GFM strikeout", "GFM Autolink", "GFM Tables"
-    };
+        {
+        "GFM strikeout", "GFM Autolink", "GFM Tables"
+        };
 
     private final static String readTextUTF_8(final InputStream in) throws IOException
     {
@@ -105,7 +105,7 @@ public class GFMTest
             final InputStream cmpIn = GFMTest.class.getResourceAsStream(RES + name + ".html");
             if (txtIn == null || cmpIn == null)
             {
-                Assert.fail("Unmatched test resources");
+                Assert.fail("Unmatched test resources: "+name);
             }
 
             final String text = readTextUTF_8(txtIn);

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/Amps and angle encoding.html
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/Amps and angle encoding.html
@@ -8,6 +8,8 @@
 
 <p>6 > 5.</p>
 
+<p>3 &lt; 4.</p>
+
 <p>Here's a <a href="http://example.com/?foo=1&amp;bar=2">link</a> with an ampersand in the URL.</p>
 
 <p>Here's a link with an amersand in the link text: <a href="http://att.com/" title="AT&amp;T">AT&amp;T</a>.</p>
@@ -15,3 +17,6 @@
 <p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
 
 <p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
+
+<p>[broken]: </p>
+ 

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/Amps and angle encoding.text
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/Amps and angle encoding.text
@@ -8,6 +8,10 @@ This & that.
 
 6 > 5.
 
+3
+<
+4.
+
 Here's a [link] [1] with an ampersand in the URL.
 
 Here's a link with an amersand in the link text: [AT&T] [2].
@@ -19,3 +23,4 @@ Here's an inline [link](</script?foo=1&bar=2>).
 
 [1]: http://example.com/?foo=1&bar=2
 [2]: http://att.com/  "AT&T"
+[broken]: 

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Autolink.html
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Autolink.html
@@ -1,0 +1,11 @@
+<h2>Auto-link in paragraph</h2>
+<p>This should be a link: <a href="http://example.com/hello-world">http://example.com/hello-world</a>.</p>
+<h2>Prevent autolink in links</h2>
+<p>This should be a link: <a href="http://example.com/hello-world">http://example.com/hello-world</a></p>
+<h2>Prevent autolink in images</h2>
+<p><img src="https://www.google.com/images/srpr/logo11w.png" alt="https://www.google.com/images/srpr/logo11w.png" /></p>
+<h2>Prevent autolink in XML tags</h2>
+<p>This should be a link: <a href='http://example.com/hello-world'>http://example.com/hello-world</a></p>
+<h2>Prevent autolink in code block</h2>
+<pre><code>This shouldn't be a link: http://example.com/hello-world.
+</code></pre>

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Autolink.text
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Autolink.text
@@ -1,0 +1,14 @@
+## Auto-link in paragraph
+This should be a link: http://example.com/hello-world.
+
+## Prevent autolink in links
+This should be a link: [http://example.com/hello-world](http://example.com/hello-world)
+
+## Prevent autolink in images
+![https://www.google.com/images/srpr/logo11w.png](https://www.google.com/images/srpr/logo11w.png)
+
+## Prevent autolink in XML tags
+This should be a link: <a href='http://example.com/hello-world'>http://example.com/hello-world</a>
+
+## Prevent autolink in code block
+	This shouldn't be a link: http://example.com/hello-world.

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Strikeout.html
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Strikeout.html
@@ -1,0 +1,11 @@
+<h2>Simple usage</h2>
+<p>Hello <del>hi</del> world!</p>
+<h2>Mixed with strong</h2>
+<p>Hello <strong><del>hi</del></strong> world!
+Hello <del><em>hi</em></del> world!</p>
+<h2>Inside code block</h2>
+<pre><code>Hello ~~hi~~ world!
+</code></pre>
+<h2>Inside GFM code block</h2>
+<pre><code>Hello ~~hi~~ world!
+</code></pre>

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Strikeout.text
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Strikeout.text
@@ -1,0 +1,19 @@
+Simple usage
+--
+Hello ~~hi~~ world!
+
+Mixed with strong
+--
+Hello **~~hi~~** world!
+Hello ~~*hi*~~ world!
+
+Inside code block
+--
+    Hello ~~hi~~ world!
+
+
+Inside GFM code block
+--
+```
+Hello ~~hi~~ world!
+```

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Tables.html
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Tables.html
@@ -1,0 +1,50 @@
+<table>
+<thead>
+<tr>
+<th>Heading 1</th><th>Heading 2</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td><td>Cell 2</td></tr>
+<tr>
+<td>Cell 3</td><td>Cell 4</td></tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th style="text-align:center;">Header 1</th><th style="text-align:right;">Header 2</th><th style="text-align:left;">Header 3</th><th>Header 4</th></tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:center;">Cell 1</td><td style="text-align:right;">Cell 2</td><td style="text-align:left;">Cell 3</td><td>Cell 4</td></tr>
+<tr>
+<td style="text-align:center;">Cell 5</td><td style="text-align:right;">Cell 6</td><td style="text-align:left;">Cell 7</td><td>Cell 8</td></tr>
+</tbody>
+</table>
+<pre><code>Test code
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Header 1</th><th>Header 2</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td><td>Cell 2</td></tr>
+<tr>
+<td>Cell 3</td><td>Cell 4</td></tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th style="text-align:left;">Header 1</th><th style="text-align:center;">Header 2</th><th style="text-align:right;">Header 3</th><th>Header 4</th></tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;">Cell 1</td><td style="text-align:center;">Cell 2</td><td style="text-align:right;">Cell 3</td><td>Cell 4</td></tr>
+<tr>
+<td style="text-align:left;"><em>Cell 5</em></td><td style="text-align:center;">Cell 6</td><td style="text-align:right;">Cell 7</td><td>Cell 8</td></tr>
+</tbody>
+</table>

--- a/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Tables.text
+++ b/src/test/resources/com/github/rjeschke/txtmark/testsuite/gfm/GFM Tables.text
@@ -1,0 +1,21 @@
+| Heading 1 | Heading 2
+| --------- | ---------
+| Cell 1    | Cell 2
+| Cell 3    | Cell 4
+
+| Header 1 | Header 2 | Header 3 | Header 4 |
+| :------: | -------: | :------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   | Cell 4   |
+| Cell 5   | Cell 6   | Cell 7   | Cell 8   |
+
+    Test code
+
+Header 1 | Header 2
+-------- | --------
+Cell 1   | Cell 2
+Cell 3   | Cell 4
+
+Header 1|Header 2|Header 3|Header 4
+:-------|:------:|-------:|--------
+Cell 1  |Cell 2  |Cell 3  |Cell 4
+*Cell 5*|Cell 6  |Cell 7  |Cell 8


### PR DESCRIPTION
**GitHub Flavored Markdown extensions**
1. Add GFM extensions not already covered by txtmark:
   - Strikethrough: ~~Mistaken text.~~
   - URL auto-linking: http:// and https:// URLs are rendered as links. Example: http://example.com  
   - Tables: see https://help.github.com/articles/github-flavored-markdown/
   
   See  `com.github.rjeschke.txtmark.GFMTest` class for **unit testing**.
2. Bug fixing:
   StringIndexOutOfBoundsException exceptions are thrown when parsing the following content:
   - `<\n` lines. Example:
   
   ```
         <
         < some text
   ```
   
    The `<\n` line will trigger an exception
   - Broken link definitions (i.e. empty URLs) like `[broken]: \n`.
     
     **Note** that processing the line `[broken]:\n` does not throw an exception but if you add a space at the end of the line: `[broken]: \n` then processing will fail with a StringIndexOutOfBoundsException.
   
   **Tests** were added in `Amps and angle encoding.text`
